### PR TITLE
Call Kit web 端使用白板文档修改超级白板版本号，Android 端 Event 文档将 onHangUp 改成 onCallEnd

### DIFF
--- a/docs_callkit_ios/09-API Reference/02-Event.mdx
+++ b/docs_callkit_ios/09-API Reference/02-Event.mdx
@@ -19,7 +19,7 @@
   -  [getMemberListviewForHeaderInSection](#getmemberlistviewforheaderinsection)
   -  [getMemberListItemHeight](#getmemberlistitemheight)
   -  [getMemberListHeaderHeight](#getmemberlistheaderheight)
-  -  [onHangUp](#onhangup)
+  -  [onCallEnd](#oncallend)
   -  [onToggleMicButtonClick](#ontogglemicbuttonclick)
   -  [onToggleCameraButtonClick](#ontogglecamerabuttonclick)
   -  [onSwitchCameraButtonClick](#onswitchcamerabuttonclick)
@@ -440,25 +440,21 @@ ZegoUIKitPrebuiltCallInvitationService.shared.callVCDelegate = self
 > }
 > ```
 
-
-
-
-
-## onHangUp
+## onCallEnd
 
 > - function prototype:
 >
 > ```swift
-> func onHangUp(_ isHandup: Bool)
+> func onCallEnd(_ endEvent: ZegoCallEndEvent)
 > ```
 >
 > - example:
 >
 > ```swift
 > extension ViewController: ZegoUIKitPrebuiltCallVCDelegate {
->   func onHangUp(_ isHandup: Bool) {
->     //...
->   }
+>     func onCallEnd(_ endEvent: ZegoCallEndEvent) {
+>         print("reason: \(String(describing: endEvent.reason)) kickerUserID: \(endEvent.kickerUserID)")
+>     }
 > }
 > ```
 

--- a/docs_callkit_web/03-Custom prebuilt features/08-Use the whiteboard.mdx
+++ b/docs_callkit_web/03-Custom prebuilt features/08-Use the whiteboard.mdx
@@ -18,14 +18,14 @@ The whiteboard now is compatible with Call Kit and Video Conference Kit, and wit
 
     ```html
     <!--add whiteboard plugins before UIKits SDK -->
-    <script src="https://unpkg.com/zego-superboard-web@2.14.1/index.js"></script>
+    <script src="https://unpkg.com/zego-superboard-web@2.15.3/index.js"></script>
     <script src="https://unpkg.com/@zegocloud/zego-uikit-prebuilt/zego-uikit-prebuilt.js"></script>
     ```
     - Method 2: Using NPM
 
     ```shell
     # install plugin
-    npm i zego-superboard-web@2.14.1 --save
+    npm i zego-superboard-web@2.15.3 --save
     ```
     ```js
     // import plugin


### PR DESCRIPTION
Call Kit web 端使用白板文档修改超级白板版本号，Android 端 Event 文档将 onHangUp 改成 onCallEnd